### PR TITLE
Set return value

### DIFF
--- a/baze.validate.js
+++ b/baze.validate.js
@@ -212,8 +212,6 @@ var BazeValidate = (function ($) {
   function clearMessage( form ) {
     var msg = form.find('.' + options.classMsg);
 
-    // if ( !msg.length ) return;
-
     msg.remove();
   }
 


### PR DESCRIPTION
Set return value default to `true` instead of `undefined` for each return early validation. fix issue #3 
